### PR TITLE
added redirect for the root url to the vite welcome page

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: python ./backend/manage.py runserver
+react: npm run dev --prefix ./frontend

--- a/backend/MovieTicketingProject/urls.py
+++ b/backend/MovieTicketingProject/urls.py
@@ -16,8 +16,10 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path,include
+from django.views.generic.base import RedirectView
 
 urlpatterns = [
+    path('', RedirectView.as_view(url='http://localhost:5173', permanent=True), name='redirect_landing_page'),
     path('admin/', admin.site.urls),
     path('api/v1/users/',include('users.urls'))
 ]

--- a/backend/Pipfile
+++ b/backend/Pipfile
@@ -12,6 +12,7 @@ django-cors-headers = "*"
 psycopg = "*"
 djangorestframework-simplejwt = "*"
 mysqlclient = "*"
+honcho = "*"
 
 [dev-packages]
 


### PR DESCRIPTION
Now when you run the python server and the vite server and then navigates to localhost:8000, they are redirected to the vite welcome.tsx page. 
the Two servers can be run at ago using the honcho start command
included honcho python library to run both the python server and the vte server at ago using the command "honcho start"